### PR TITLE
Changes DefaultWorkQueue maxSize to atomic

### DIFF
--- a/internal/compute/work_queue_test.go
+++ b/internal/compute/work_queue_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -30,7 +31,7 @@ func TestNewQueue(t *testing.T) {
 			expect: &DefaultWorkQueue{
 				pool:    nil,
 				workers: nil,
-				maxSize: 5,
+				maxSize: atomic.NewUint32(5),
 			},
 		},
 	}


### PR DESCRIPTION
Instead of using the mutex to manage both the worker list and the
maxSize attribute, the maxSize is now an atomic uint32 using
go.uber.org/zap package.

Signed-off-by: Anshul Gupta <ansg191@yahoo.com>
