### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Ignores semver patches fro aws-sdk-go-v2